### PR TITLE
Change `name` to be consistent with standards.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-module-secure-passwords",
+	"name": "@newfold-labs/wp-module-secure-passwords",
 	"description": "Stuff",
 	"license": "GPL-2.0-or-later",
 	"private": true,


### PR DESCRIPTION
The `name` field for npm packages should be `@newfold-labs/wp-module-name`, even if not consumed as an npm dependency.