### PR TITLE
Don't check for insecure passwords on local environments

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -109,6 +109,11 @@ function record_password_check( $user_id ) {
  * @return bool Whether the password should be checked for security.
  */
 function should_check_password( $user_id ) {
+
+	if ( wp_get_environment_type() === 'local' ) {
+		return false;
+	}
+
 	// Password is not currently marked as insecure. Check every 30 days.
 	$last_check = (int) get_user_meta( $user_id, 'nfd_sp_last_check', true );
 


### PR DESCRIPTION
## Proposed changes

Currently, when using our Newfold local environment, we simply use the `admin` username and `password` password. As such, the insecure password screen interferes with being able to test our other modules, like onboarding. This change is to check if we're on a local environment and simply don't check for insecure passwords on these environments.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
