### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write       # Required for reusable workflow to commit updated translation files.
       pull-requests: write  # Required for reusable workflow to open or update translation PRs.
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-secure-passwords'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,7 +23,6 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to commit updated translation files.
       pull-requests: write # Required for reusable workflow to open or update translation PRs.
-    timeout-minutes: 30
     with:
       text_domain: 'wp-module-secure-passwords'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write       # Required for reusable workflow to commit updated translation files.
+      pull-requests: write  # Required for reusable workflow to open or update translation PRs.
     with:
       text_domain: 'wp-module-secure-passwords'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -21,8 +21,8 @@ jobs:
     name: 'Check and update translations'
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
-      contents: write       # Required for reusable workflow to commit updated translation files.
-      pull-requests: write  # Required for reusable workflow to open or update translation PRs.
+      contents: write      # Required for reusable workflow to commit updated translation files.
+      pull-requests: write # Required for reusable workflow to open or update translation PRs.
     timeout-minutes: 30
     with:
       text_domain: 'wp-module-secure-passwords'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+permissions: {}
     timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for default token when invoking reusable workflows that clone repositories.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -35,6 +36,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for default token when invoking reusable workflows that clone repositories.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -47,6 +49,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for default token when invoking reusable workflows that clone repositories.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,7 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Required for default token when invoking reusable workflows that clone repositories.
+      contents: read
     timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -35,7 +35,7 @@ jobs:
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
-      contents: read # Required for default token when invoking reusable workflows that clone repositories.
+      contents: read
     timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
@@ -48,7 +48,7 @@ jobs:
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
-      contents: read # Required for default token when invoking reusable workflows that clone repositories.
+      contents: read
     timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -36,7 +36,6 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read
-    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -49,7 +48,6 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read
-    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,20 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for default token when invoking reusable workflows that clone repositories.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for default token when invoking reusable workflows that clone repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +44,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for default token when invoking reusable workflows that clone repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No repository checkout or GitHub API access required.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write       # Required for pushing coverage HTML to GitHub Pages.
+      pull-requests: write  # Required for reusable workflow PR annotations and checks.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No repository checkout or GitHub API access required.
+    timeout-minutes: 30
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write       # Required for pushing coverage HTML to GitHub Pages.
       pull-requests: write  # Required for reusable workflow PR annotations and checks.
+    timeout-minutes: 30
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,7 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No repository checkout or GitHub API access required.
-    timeout-minutes: 30
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -35,7 +35,6 @@ jobs:
     permissions:
       contents: write       # Required for pushing coverage HTML to GitHub Pages.
       pull-requests: write  # Required for reusable workflow PR annotations and checks.
-    timeout-minutes: 30
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,7 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # WEBHOOK_TOKEN is used for repository-dispatch; default GITHUB_TOKEN is not used against the API.
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # WEBHOOK_TOKEN is used for repository-dispatch; default GITHUB_TOKEN is not used against the API.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # WEBHOOK_TOKEN is used for repository-dispatch; default GITHUB_TOKEN is not used against the API.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 4 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/auto-translate.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `6cb62af` |
| Timeouts commit | `942a3cb` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/auto-translate.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml` :: workflow root: BEFORE `permissions: contents: read` -> AFTER `# Disable permissions…` + `permissions: {}` -- workflow-level default deny per GitHub Actions permissions model ([workflow `permissions`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)) -- [3] |
| 2 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml` :: workflow root: BEFORE `permissions: contents: read` -> AFTER `# Disable permissions…` + `permissions: {}` -- same -- [3] |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/satis-update.yml` :: workflow root: BEFORE (no workflow-level `permissions`) -> AFTER `# Disable permissions…` + `permissions: {}` -- same -- [3] |
| 4 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/auto-translate.yml` :: workflow root: BEFORE `permissions: {}` without the required preceding comment banner -> AFTER comment banner + `permissions: {}` -- matches audit-required formatting -- [3] |
| 5 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml` :: `codecoverage`: BEFORE undifferentiated `contents`/`pull-requests` grants without inline rationales -> AFTER same scopes with aligned trailing comments; `permissions` placed immediately after `uses:` -- documents least-privilege intent for reusable coverage + Pages/PR behavior -- [2] |
| 6 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml` :: `setup`, `bluehost`, `bluehost-dev`: BEFORE `contents: read` without per-permission comments / `uses:` not immediately followed by `permissions:` -> AFTER `uses:` then `permissions:` with `# Required for default token when invoking reusable workflows that clone repositories.` -- clarifies why `contents: read` remains for private-repo reusable calls -- [2] |
| 7 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/auto-translate.yml` :: `translate`: BEFORE undifferentiated grants -> AFTER same scopes with aligned trailing comments; `permissions` placed immediately after `uses:` -- documents translator reusable workflow needs -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml | get-repo-name | `30` | bounds a tiny helper job so a hung runner cannot burn minutes indefinitely. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/codecoverage-main.yml | codecoverage | `30` | caps runtime for the reusable multi-PHP coverage workflow while staying generous enough for typical CI use. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml | setup | `30` | branch extraction should finish quickly; timeout prevents a stuck job. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml | bluehost | `30` | bounds Playwright-driven reusable-plugin testing without altering existing behavior. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/brand-plugin-test-playwright.yml | bluehost-dev | `30` | same rationale as `bluehost` for the alternate plugin branch matrix. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/auto-translate.yml | translate | `30` | translation reusable jobs should complete well under this cap unless upstream APIs stall. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-secure-passwords/.github/workflows/satis-update.yml | webhook | `30` | repository-dispatch path is short; prevents runaway retries or hangs. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Reusable workflows under `newfold-labs/workflows` (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`, `reusable-translations.yml`) were not checked out in this run; confirm their documented token usage still matches `contents: write`, `pull-requests: write`, and `contents: read` assumptions—especially if those workflows gain new GitHub API surfaces later. |
| 2 | `peter-evans/repository-dispatch@v1` is driven by `secrets.WEBHOOK_TOKEN`; job-level `permissions: {}` assumes the default `GITHUB_TOKEN` is unused—verify if future steps add checkout/`gh`/GitHub-script usage. |


