### PR TITLE
Skip AI code review on Dependabot PRs

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -21,7 +21,13 @@ permissions: {}
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    # Skip Dependabot PRs: GitHub withholds repo secrets from Dependabot-context
+    # runs, so the AI gateway secrets are empty and the review would hard-fail.
+    # A skipped job counts as passing, so it never blocks Dependabot auto-merge.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'
     name: Review PR diff
     uses: newfold-labs/workflows/.github/workflows/reusable-code-review.yml@main
     with:


### PR DESCRIPTION
## Summary
- Skip the AI code review workflow when the PR author is Dependabot
- GitHub withholds org secrets from Dependabot-context runs, which caused the workflow to hard-fail and block auto-merge

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm AI code review still runs on normal PRs
- [ ] Confirm Dependabot PRs skip the review job (job shows as skipped, not failed)