### PR TITLE
ci: add scheduled Dependabot auto-merge caller (PRESS0-4266)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot Auto-Merge
+on:
+  schedule:
+    # Two sweeps a day so a freshly-green (or freshly-rebased) Dependabot PR is
+    # merged within hours instead of waiting a full day. The sweep is cheap.
+    - cron: "0 6 * * *"
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log what would be merged without merging.
+        type: boolean
+        default: false
+
+# Disable permissions for all scopes by default; grant only what the job needs.
+permissions: {}
+
+jobs:
+  # Delegates to the central reusable sweep in newfold-labs/workflows. It finds
+  # every open Dependabot PR and merges the eligible ones (not draft, mergeable,
+  # all check runs green, an opted-in bump type). Majors are left for a human.
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    uses: newfold-labs/workflows/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    with:
+      merge-method: squash
+      update-types: patch,minor
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+    # checks: read lets the reusable read check-run status via the Checks API.
+    # GITHUB_TOKEN reaches the called workflow automatically — no secrets: inherit.
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`, a thin caller that delegates to the org-wide reusable sweep at `newfold-labs/workflows/.github/workflows/reusable-dependabot-auto-merge.yml@main`.

## Why

Part of the fleet-wide scheduled Dependabot auto-merge rollout (PRESS0-4266). Twice-daily, the reusable finds every open Dependabot PR and merges the eligible ones — not draft, mergeable, all check runs green, and an opted-in bump type (`patch`, `minor`). Major bumps are left for a human to review.

## Notes

- Config-only: adds a single workflow file, no source changes.
- The AI-code-review Dependabot skip is already merged in this repo, so reviews won't block auto-merge (a skipped job counts as passing).
- No change to `dependabot.yml` — updates stay ungrouped so a single bad bump never blocks the rest.
- Scheduled workflows fire from the default branch (`main`), which is where this caller lands.
- Manual `workflow_dispatch` supports a `dry-run` input to preview what would be merged.
